### PR TITLE
make updating a task not require a userId and _id anymore

### DIFF
--- a/packages/api/src/task.api.ts
+++ b/packages/api/src/task.api.ts
@@ -13,6 +13,6 @@ export const TaskApi = defineAPI({
   getTaskList: GET `/tasks` // prettier-ignore
     .response(Array(TaskEntity)),
   updateTask: PUT `/tasks/${'id'}` // prettier-ignore
-    .body(TaskEntity)
+    .body(Task)
     .response(TaskEntity)
 })


### PR DESCRIPTION
closes #56 
- Changes were only necessary in updateTask()